### PR TITLE
Group dependabot updates for github-actions to create less noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,17 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+   # Enable version updates for actions
+  - package-ecosystem: 'github-actions'
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: '/'
+    # Check the npm registry for updates every week
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
+    groups:
+      all-in-one:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This pull request includes updates to the Dependabot configuration to enable version updates for GitHub Actions and improve the update schedule. The most important changes include enabling version updates for actions, specifying the directory for package manifests, and adding a new update group for minor and patch updates.

Dependabot configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L8-R21): Enabled version updates for GitHub Actions by specifying `package-ecosystem` as `github-actions`.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L8-R21): Specified the directory for package manifests as the root directory.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L8-R21): Added a new update group named `all-in-one` to handle minor and patch updates.