### PR TITLE
skip the workflow when the Azure DevOps pat is not available

### DIFF
--- a/.github/workflows/handle-versioning-accross-branches.yml
+++ b/.github/workflows/handle-versioning-accross-branches.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   extension-versioning:
+    if: github.actor != 'dependabot[bot]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/handle-versioning-accross-branches.yml` file. The change adds a condition to the `extension-versioning` job to exclude the `dependabot[bot]` actor.

* [`.github/workflows/handle-versioning-accross-branches.yml`](diffhunk://#diff-1f1c37d1bddebd3748edf0768c614cf238b32a6afc221e763b258e2db0b3b945R12): Added a condition to the `extension-versioning` job to exclude the `dependabot[bot]` actor.