### PR TITLE
fix: unpin tfx-cli so Dependabot can update it

### DIFF
--- a/widgets/package.json
+++ b/widgets/package.json
@@ -12,7 +12,7 @@
     "@types/q": "^1.5.8",
     "install": "^0.13.0",
     "npm": "^11.12.1",
-    "tfx-cli": "0.23.1",
+    "tfx-cli": "^0.23.1",
     "vitest": "^4.1.2",
     "vss-web-extension-sdk": "^5.141.0"
   },


### PR DESCRIPTION
## Why

The `widgets/package.json` had `tfx-cli` pinned to an exact version (`"0.23.1"`). GitHub code scanning flagged this as a **"Pinned dependency"** alert — exact-version pins block Dependabot from raising update PRs, meaning security and bug-fix releases go undetected.

## What changed

- `widgets/package.json`: changed `"tfx-cli": "0.23.1"` → `"tfx-cli": "^0.23.1"`, aligning it with all other dependencies that already use caret ranges.

Dependabot is already configured to watch `/widgets` in `.github/dependabot.yml`, so no changes to that file are needed — it will now pick up future tfx-cli updates automatically.