### PR TITLE
fix: quick wins - rename workflow, add tests, fix vsix var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,11 @@ jobs:
         run: |
           .\make.ps1 -command "build" -skipPublish
 
+      - name: Install dev dependencies for tests
+        run: |
+          cd widgets && npm ci
+          cd ../dependencyReviewTask && npm ci
+          cd ..
+
       - name: Run tests
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,6 @@ jobs:
         shell: pwsh
         run: |
           .\make.ps1 -command "build" -skipPublish
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/handle-versioning-across-branches.yml
+++ b/.github/workflows/handle-versioning-across-branches.yml
@@ -1,8 +1,11 @@
-name: Handle versioning accros branches
+name: Handle versioning across branches
 
 on:
   push:
-    # todo: add file paths of the files with version numbers
+    paths:
+      - 'dependencyReviewTask/task.json'
+      - 'vss-extension-dev.json'
+      - 'vss-extension.json'
 
 permissions:
   contents: read
@@ -37,13 +40,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get highest version number accross all branches
+      - name: Get highest version number across all branches
         id: get-version
         shell: pwsh
         env:
           AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT}}
         run: |
           # get the last updated version for this extension from the server
+          $vsix = "vss-extension-dev.json"
           $output = $(npx tfx extension show --token $env:AZURE_DEVOPS_PAT --vsix $vsix --publisher "RobBos" --extension-id "GHAzDoWidget-DEV" --output json | ConvertFrom-Json)
           if ($null -eq $output) {
             Write-Host "No versions found on the server"
@@ -69,7 +73,6 @@ jobs:
           }
 
           # loop over all branches
-          $highestVersion = 0
           foreach ($branch in $(git branch -r --format='%(refname:short)')) {
             Write-Host "Checkout the branch [$branch]"
             git checkout $branch


### PR DESCRIPTION
## Summary
Implements quick win improvements identified in repo analysis:

### Changes Made

1. **Renamed versioning workflow** (`handle-versioning-accross-branches.yml` → `handle-versioning-across-branches.yml`)
   - Fixed typo in filename (accross → across)
   - Updated workflow name header to match

2. **Fixed versioning workflow bugs**
   - Added missing `$vsix = "vss-extension-dev.json"` variable definition (was undefined)
   - Removed redundant `$highestVersion = 0` assignment that was overwriting the object
   - Added `paths` filter to trigger workflow only when version files change

3. **Added tests to CI**
   - Added `Run tests` step to `ci.yml` that executes `npm test`

### Testing
- CI workflow validates: Build succeeds and tests run
- Versioning workflow validates: Correctly fetches versions from Azure DevOps

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>
