### PR TITLE
fix: pin npm commands with npm ci (Pinned-Dependencies #16 and #17)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
         run: npm ci
 
       - name: Install widget dependencies
-        run: npm install
+        run: npm ci
         working-directory: widgets
 
       - name: Build pipeline task
         run: |
-          npm install --ignore-scripts
+          npm ci --ignore-scripts
           npx tsc -p .
           npm prune --omit=dev
         working-directory: dependencyReviewTask


### PR DESCRIPTION
## Summary

Fixes OpenSSF Scorecard **Pinned-Dependencies** code scanning alerts #16 and #17 in `.github/workflows/release.yml`.

## Changes

Both `npm install` commands were replaced with `npm ci`:

- **Alert #16** (line 33): `npm install` → `npm ci` in the `widgets` directory
- **Alert #17** (line 37): `npm install --ignore-scripts` → `npm ci --ignore-scripts` in the `dependencyReviewTask` directory

## Why

`npm ci` uses `package-lock.json` to install exact, reproducible dependency versions — packages are verified against the lockfile hashes. `npm install` can modify the lockfile and resolve to different versions, which is flagged by the OpenSSF Scorecard Pinned-Dependencies check.

Both `widgets/` and `dependencyReviewTask/` already have `package-lock.json` files, so `npm ci` works without any other changes.