### PR TITLE
fix: upgrade uuid to ^14.0.0 (dependabot alerts #89, #90, #91)

### DIFF
--- a/dependencyReviewTask/package-lock.json
+++ b/dependencyReviewTask/package-lock.json
@@ -2296,13 +2296,16 @@
             "license": "(WTFPL OR MIT)"
         },
         "node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "bin/uuid"
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/vite": {

--- a/dependencyReviewTask/package.json
+++ b/dependencyReviewTask/package.json
@@ -6,6 +6,9 @@
         "coverage": "vitest run --coverage",
         "precoverage": "tsc -p ."
     },
+    "overrides": {
+        "uuid": "^14.0.0"
+    },
     "dependencies": {
         "azure-devops-node-api": "^15.1.2",
         "azure-pipelines-task-lib": "^5.2.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3740,9 +3740,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "tfx-cli": "^0.23.1"
   },
+  "overrides": {
+    "uuid": "^14.0.0"
+  },
   "scripts": {
     "install-tfx": "npm install",
     "test": "npm --prefix widgets test && npm --prefix dependencyReviewTask test",

--- a/widgets/package-lock.json
+++ b/widgets/package-lock.json
@@ -6507,9 +6507,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/widgets/package.json
+++ b/widgets/package.json
@@ -8,6 +8,9 @@
     "test": "vitest run",
     "coverage": "vitest run --coverage"
   },
+  "overrides": {
+    "uuid": "^14.0.0"
+  },
   "devDependencies": {
     "@types/node": "^25",
     "@types/q": "^1.5.8",


### PR DESCRIPTION
## Summary

Fixes dependabot alerts [#89](../../security/dependabot/89), [#90](../../security/dependabot/90), and [#91](../../security/dependabot/91).

**Vulnerability:** `uuid` — Missing buffer bounds check in v3/v5/v6 when `buf` is provided (medium severity)  
**Fixed in:** uuid 14.0.0

## Changes

Added npm `overrides` to force `uuid` to `^14.0.0` in three locations where it was pulled in as a transitive dependency:

| Manifest | Parent package | Old version | New version |
|---|---|---|---|
| `package-lock.json` | `tfx-cli@0.23.1` | 13.0.0 | 14.0.0 |
| `dependencyReviewTask/package-lock.json` | `azure-pipelines-task-lib@5.2.10` | 3.4.0 | 14.0.0 |
| `widgets/package-lock.json` | `tfx-cli@0.23.1` | 13.0.0 | 14.0.0 |