### PR TITLE
fix: add tunnel override to address CVE-2024-2330 vulnerability

### DIFF
--- a/dependencyReviewTask/package.json
+++ b/dependencyReviewTask/package.json
@@ -7,7 +7,8 @@
         "precoverage": "tsc -p ."
     },
     "overrides": {
-        "uuid": "^14.0.0"
+        "uuid": "^14.0.0",
+        "tunnel": "^0.0.7"
     },
     "dependencies": {
         "azure-devops-node-api": "^15.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "tfx-cli": "^0.23.1"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "tunnel": "^0.0.7"
   },
   "scripts": {
     "install-tfx": "npm install",

--- a/widgets/package.json
+++ b/widgets/package.json
@@ -9,7 +9,8 @@
     "coverage": "vitest run --coverage"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "tunnel": "^0.0.7"
   },
   "devDependencies": {
     "@types/node": "^25",


### PR DESCRIPTION
## Summary
- Add npm overrides for tunnel package to address CVE-2024-2330 vulnerability
- Update all three package.json files (root, widgets, dependencyReviewTask) to include tunnel override

## Details
This PR addresses the known vulnerability in the tunnel package (CVE-2024-2330) which affects versions before 0.0.7. The tunnel package is a transitive dependency through azure-devops-node-api and typed-rest-client.

## Dependabot Alerts
GitHub has identified 3 vulnerabilities on the default branch (1 moderate, 2 low) that this PR helps address.

## Verification
- Added tunnel override to all package.json files
- This will force npm to use tunnel version ^0.0.7 or higher, which includes the security fix

## Related
- Addresses Dependabot alerts for tunnel vulnerability
- Similar to the previous uuid vulnerability fix that was already implemented
