### PR TITLE
fix: add semver override to address CVE-2022-25883 vulnerability

### DIFF
--- a/dependencyReviewTask/package.json
+++ b/dependencyReviewTask/package.json
@@ -7,7 +7,8 @@
         "precoverage": "tsc -p ."
     },
     "overrides": {
-        "uuid": "^14.0.0"
+        "uuid": "^14.0.0",
+        "semver": "^7.5.4"
     },
     "dependencies": {
         "azure-devops-node-api": "^15.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "tfx-cli": "^0.23.1"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "semver": "^7.5.4"
   },
   "scripts": {
     "install-tfx": "npm install",

--- a/widgets/package.json
+++ b/widgets/package.json
@@ -9,7 +9,8 @@
     "coverage": "vitest run --coverage"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@types/node": "^25",


### PR DESCRIPTION
## Summary
- Add npm overrides for semver package to address CVE-2022-25883 vulnerability
- Update all three package.json files (root, widgets, dependencyReviewTask) to include semver override

## Details
This PR addresses the known regular expression denial of service vulnerability in the semver package (CVE-2022-25883) which affects versions before 7.5.4. The semver package is a transitive dependency through various packages in the dependency tree.

## Dependabot Alerts
GitHub has identified 3 vulnerabilities on the default branch (1 moderate, 2 low) that this PR helps address.

## Verification
- Added semver override to all package.json files
- This will force npm to use semver version ^7.5.4 or higher, which includes the security fix

## Related
- Addresses Dependabot alerts for semver vulnerability
- Similar to the previous uuid vulnerability fix that was already implemented
